### PR TITLE
chore: add CODEOWNERS + branch protection checklist

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default owners for the repo.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @RedLynx101
+
+# Higher-sensitivity areas
+/.github/workflows/ @RedLynx101
+/SECURITY.md @RedLynx101
+/docs/security/ @RedLynx101
+/docs/ops/ @RedLynx101

--- a/README.md
+++ b/README.md
@@ -19,4 +19,7 @@ Maintained by **Metanoia** (Jarvis’s public-facing identity) under Noah’s ac
 - Fork-first (recommended)
 - PRs only; no direct pushes to `main`
 
-See: `docs/AGENT_ONBOARDING.md`
+Key docs:
+- Onboarding: `docs/AGENT_ONBOARDING.md`
+- Recommended branch protection: `docs/ops/branch-protection.md`
+- Code owners: `.github/CODEOWNERS`

--- a/docs/ops/branch-protection.md
+++ b/docs/ops/branch-protection.md
@@ -1,0 +1,30 @@
+# Branch protection (recommended)
+
+This repo is designed to be PR-only. The point of this document is to make the *expected* GitHub settings explicit.
+
+## Main branch (`main`)
+
+Recommended settings:
+- Require a pull request before merging
+  - Require approvals: **1+**
+  - Dismiss stale approvals when new commits are pushed
+  - Require review from Code Owners (see `.github/CODEOWNERS`)
+- Require status checks to pass before merging
+  - Require branches to be up to date before merging
+  - Suggested required checks:
+    - CI / test
+    - Lint / format (if present)
+    - Security / scan (if present)
+- Require conversation resolution before merging
+- Require signed commits (optional, but encouraged)
+- Do not allow force pushes
+- Do not allow deletions
+
+## Tags / releases (optional)
+
+If you publish release artifacts:
+- Restrict who can create or delete tags
+
+## Notes
+
+GitHub settings live outside the repo. This document exists so maintainers can quickly verify the repo is configured safely.


### PR DESCRIPTION
Implements issue #5.

## What
- Adds .github/CODEOWNERS with sane defaults
- Adds docs/ops/branch-protection.md with recommended settings

## Receipt
- Goal: ensure maintainer review + document branch protection baseline
- Changes: CODEOWNERS + branch protection doc
- Verification: docs render correctly; no CI changes

Closes #5