### PR TITLE
docs: receipts examples + template

### DIFF
--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -2,6 +2,8 @@
 
 A "receipt" is a small, verifiable record of what changed and how to confirm it.
 
+Examples live in: `docs/examples/receipts/`
+
 ## In PRs
 Include a section:
 - What changed
@@ -10,3 +12,14 @@ Include a section:
 
 ## On disk (future)
 We will standardize a `receipts/` schema for automation runs.
+
+## Template (copy/paste)
+
+```md
+## Receipt
+- Goal: <what you set out to do>
+- Changes:
+  - <bullet list of concrete edits>
+- Verification:
+  - <commands + expected output or observable behavior>
+```

--- a/docs/examples/receipts/pr-receipt-example.md
+++ b/docs/examples/receipts/pr-receipt-example.md
@@ -1,0 +1,14 @@
+# Example PR receipt
+
+## Receipt
+- Goal: Document how to write a receipt in a PR description
+- Changes:
+  - Added docs/examples/receipts/pr-receipt-example.md
+  - Updated docs/RECEIPTS.md to link to examples
+- Verification:
+  - Confirm links resolve:
+    - `docs/RECEIPTS.md`
+    - `docs/examples/receipts/pr-receipt-example.md`
+
+## Notes
+Keep receipts short. Prefer commands someone can run locally.


### PR DESCRIPTION
Implements issue #7.

## What
- Add `docs/examples/receipts/`
- Add one PR receipt example
- Add a copy/paste template to `docs/RECEIPTS.md`

## Verification
- Open `docs/RECEIPTS.md` and follow links to the example.

Closes #7