### PR TITLE
Add receipt schema + CI lint for agent verification

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,20 @@
 
 ## Why
 
+## Receipt
+- Goal:
+- Changes:
+  -
+- Verification:
+  - Command:
+    - Expect:
+
 ## How to verify
 
 ## Risks / notes
 
 ## Checklist
 - [ ] Linked issue
+- [ ] Receipt section completed
 - [ ] Tests or rationale
 - [ ] No secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,14 @@ jobs:
           set -euo pipefail
           echo "swarmkit CI: sanity"
           git status --porcelain
+
+      - name: Receipt lint (if present)
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+          files=(receipts/**/*.json receipts/*.json docs/examples/receipts/*.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No receipt files found; skipping"
+            exit 0
+          fi
+          python3 tools/receipt_lint.py "${files[@]}"

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -10,8 +10,21 @@ Include a section:
 - Why
 - How to verify (commands + expected output)
 
-## On disk (future)
-We will standardize a `receipts/` schema for automation runs.
+## On disk (JSON schema)
+For automation-friendly workflows, store machine-readable receipts as JSON and validate them in CI.
+
+- Schema: `docs/receipts.schema.json`
+- Linter: `tools/receipt_lint.py`
+- Example: `docs/examples/receipts/receipt.sample.json`
+
+Recommended location for real run receipts: `receipts/YYYY-MM-DD/*.json`
+
+### Required fields (`version: "1.0"`)
+- `goal` (string)
+- `changes` (non-empty list of strings)
+- `verification` (non-empty list of `{ command, expect }` objects)
+- `timestamp` (UTC ISO 8601)
+- `actor` (string)
 
 ## Template (copy/paste)
 
@@ -22,4 +35,10 @@ We will standardize a `receipts/` schema for automation runs.
   - <bullet list of concrete edits>
 - Verification:
   - <commands + expected output or observable behavior>
+```
+
+## JSON quickstart
+
+```bash
+python3 tools/receipt_lint.py docs/examples/receipts/receipt.sample.json
 ```

--- a/docs/examples/receipts/receipt.sample.json
+++ b/docs/examples/receipts/receipt.sample.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "goal": "Introduce a machine-verifiable receipt schema and CI receipt linting.",
+  "changes": [
+    "Added docs/receipts.schema.json with required receipt fields.",
+    "Added tools/receipt_lint.py for schema-level checks without external dependencies.",
+    "Updated CI to validate all receipts/*.json files."
+  ],
+  "verification": [
+    {
+      "command": "python3 tools/receipt_lint.py docs/examples/receipts/receipt.sample.json",
+      "expect": "PASS"
+    }
+  ],
+  "risks": [
+    "Schema may need expansion as automation coverage grows."
+  ],
+  "files_touched": [
+    "docs/receipts.schema.json",
+    "tools/receipt_lint.py",
+    ".github/workflows/ci.yml"
+  ],
+  "timestamp": "2026-02-07T06:45:00Z",
+  "actor": "swarmkit-agent",
+  "links": [
+    "https://github.com/redlynx101/swarmkit"
+  ]
+}

--- a/docs/receipts.schema.json
+++ b/docs/receipts.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/redlynx101/swarmkit/docs/receipts.schema.json",
+  "title": "Swarmkit Receipt",
+  "description": "Machine-verifiable record for agent-run changes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "goal",
+    "changes",
+    "verification",
+    "timestamp",
+    "actor"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "goal": {
+      "type": "string",
+      "minLength": 1
+    },
+    "changes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "verification": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["command", "expect"],
+        "properties": {
+          "command": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expect": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "files_touched": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "actor": {
+      "type": "string",
+      "minLength": 1
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      },
+      "default": []
+    }
+  }
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,9 @@
 
 Standalone utilities (CLI/scripts) for maintaining agent workflows.
 
+Available:
+- `receipt_lint.py` — validates receipt JSON files against Swarmkit's required fields
+
 Planned:
 - task-broker (issue → agent brief)
-- receipt-linter
 - suspicious-change scanner

--- a/tools/receipt_lint.py
+++ b/tools/receipt_lint.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate Swarmkit receipt JSON files.
+
+Deliberately dependency-free so it can run in minimal CI environments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ISO_8601_UTC = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+class ReceiptError(Exception):
+    pass
+
+
+def _require(condition: bool, msg: str) -> None:
+    if not condition:
+        raise ReceiptError(msg)
+
+
+def _is_nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def validate_receipt(payload: dict[str, Any], source: str) -> None:
+    required = ["version", "goal", "changes", "verification", "timestamp", "actor"]
+    for key in required:
+        _require(key in payload, f"{source}: missing required field '{key}'")
+
+    _require(payload["version"] == "1.0", f"{source}: version must be '1.0'")
+    _require(_is_nonempty_string(payload["goal"]), f"{source}: goal must be a non-empty string")
+    _require(_is_nonempty_string(payload["actor"]), f"{source}: actor must be a non-empty string")
+
+    changes = payload["changes"]
+    _require(isinstance(changes, list) and len(changes) > 0, f"{source}: changes must be a non-empty list")
+    for idx, change in enumerate(changes, start=1):
+        _require(_is_nonempty_string(change), f"{source}: changes[{idx}] must be a non-empty string")
+
+    verification = payload["verification"]
+    _require(
+        isinstance(verification, list) and len(verification) > 0,
+        f"{source}: verification must be a non-empty list",
+    )
+    for idx, step in enumerate(verification, start=1):
+        _require(isinstance(step, dict), f"{source}: verification[{idx}] must be an object")
+        _require(_is_nonempty_string(step.get("command")), f"{source}: verification[{idx}].command required")
+        _require(_is_nonempty_string(step.get("expect")), f"{source}: verification[{idx}].expect required")
+
+    timestamp = payload["timestamp"]
+    _require(_is_nonempty_string(timestamp), f"{source}: timestamp must be a non-empty string")
+    _require(bool(ISO_8601_UTC.match(timestamp)), f"{source}: timestamp must be ISO8601 UTC (YYYY-MM-DDTHH:MM:SSZ)")
+    try:
+        dt.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as exc:
+        raise ReceiptError(f"{source}: invalid timestamp value: {exc}") from exc
+
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ReceiptError(f"{path}: invalid JSON ({exc})") from exc
+    _require(isinstance(data, dict), f"{path}: root JSON value must be an object")
+    return data
+
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Swarmkit receipt JSON files")
+    parser.add_argument("paths", nargs="+", help="Receipt JSON file(s) to validate")
+    args = parser.parse_args()
+
+    failures = 0
+    for raw in args.paths:
+        path = Path(raw)
+        if not path.exists():
+            print(f"FAIL {path}: file not found", file=sys.stderr)
+            failures += 1
+            continue
+        try:
+            payload = load_json(path)
+            validate_receipt(payload, str(path))
+            print(f"PASS {path}")
+        except ReceiptError as exc:
+            print(f"FAIL {exc}", file=sys.stderr)
+            failures += 1
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements a high-leverage Phase 1 backlog slice by standardizing machine-readable receipts and validating them in CI.

## What changed
- Added  (v1.0 receipt schema)
- Added  (dependency-free validator)
- Added 
- Updated CI to lint receipt JSON files when present
- Updated PR template with a required Receipt section
- Updated docs (, )

## Verification
- PASS docs/examples/receipts/receipt.sample.json
- Simulated CI receipt lint command locally (glob expansion + validator)

## Risks / notes
Schema may evolve as additional receipt use-cases emerge.