### PR TITLE
Add task broker CLI for issue → brief generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,8 @@ jobs:
             exit 0
           fi
           python3 tools/receipt_lint.py "${files[@]}"
+
+      - name: Tooling unit tests
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s tools -p 'test_*.py'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,19 @@ jobs:
         run: |
           set -euo pipefail
           python3 -m unittest discover -s tools -p 'test_*.py'
+
+      - name: Risk scan (warn)
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DIFF_REF="${{ github.event.pull_request.base.sha }}..${{ github.sha }}"
+          else
+            DIFF_REF="${{ github.event.before }}..${{ github.sha }}"
+          fi
+
+          # First push in a repo can have a null "before" sha.
+          if [ "$DIFF_REF" = "0000000000000000000000000000000000000000..${{ github.sha }}" ]; then
+            DIFF_REF="HEAD~1..HEAD"
+          fi
+
+          python3 tools/risk_scan.py --diff-ref "$DIFF_REF"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Maintained by **Metanoia** (Jarvis’s public-facing identity) under Noah’s ac
 
 ## What’s in here (initial)
 - `docs/` — onboarding, runbooks, ADRs
-- `.github/` — issue/PR templates
+- `.github/` — issue/PR templates + CI workflow
+- `tools/` — receipt lint, task broker, and risk scanning utilities
 
 ## Contribution model
 - Fork-first (recommended)

--- a/docs/ISSUE_BRIEFS.md
+++ b/docs/ISSUE_BRIEFS.md
@@ -12,3 +12,12 @@ To make agent contributions high-quality, issues should read like a work order.
 
 ## Why
 Agents can implement quickly, but need tight intent and verification.
+
+## CLI helper
+Use the task broker utility to generate a draft brief from an existing issue:
+
+```bash
+python3 tools/task_broker.py --repo RedLynx101/swarmkit --issue 8 --out docs/briefs/issue-8.md
+```
+
+It reads issue metadata/body and maps common sections into the template above, with sensible defaults when issue text is incomplete.

--- a/docs/projects/initial_backlog.md
+++ b/docs/projects/initial_backlog.md
@@ -9,7 +9,8 @@
 - Add PR template sections enforcing verification
 
 ## P2: Risk scanning
-- CI: flag risky diffs (network/exec/deps)
+- [x] CI: flag risky diffs (network/exec/deps) via `tools/risk_scan.py`
+- [ ] Optional follow-up: enforce fail-on-findings for protected branches after tuning
 
 ## P3: Maintenance patterns
 - Marker files + backfill runner pattern

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,7 +4,15 @@ Standalone utilities (CLI/scripts) for maintaining agent workflows.
 
 Available:
 - `receipt_lint.py` — validates receipt JSON files against Swarmkit's required fields
+- `risk_scan.py` — scans git diffs for high-risk path and line-level changes
+- `task_broker.py` — generates agent-ready implementation briefs from GitHub issues
+
+Example:
+- `python3 tools/task_broker.py --repo RedLynx101/swarmkit --issue 8 --out docs/briefs/issue-8.md`
+- `python3 tools/task_broker.py --issue-url https://github.com/RedLynx101/swarmkit/issues/8`
+
+Tests:
+- `python3 -m unittest discover -s tools -p 'test_*.py'`
 
 Planned:
-- task-broker (issue → agent brief)
 - suspicious-change scanner

--- a/tools/README.md
+++ b/tools/README.md
@@ -7,6 +7,15 @@ Available:
 - `risk_scan.py` — scans git diffs for high-risk path and line-level changes
 - `task_broker.py` — generates agent-ready implementation briefs from GitHub issues
 
+`risk_scan.py` highlights:
+- dependency manifests (`requirements.txt`, `pyproject.toml`, `package.json`, lockfiles, etc.)
+- GitHub workflow edits (`.github/workflows/*`)
+- added diff lines introducing network calls or process/shell execution
+
+Example:
+- `python3 tools/risk_scan.py --diff-ref HEAD~1..HEAD`
+- `python3 tools/risk_scan.py --diff-ref origin/main..HEAD --fail-on-findings`
+
 Example:
 - `python3 tools/task_broker.py --repo RedLynx101/swarmkit --issue 8 --out docs/briefs/issue-8.md`
 - `python3 tools/task_broker.py --issue-url https://github.com/RedLynx101/swarmkit/issues/8`

--- a/tools/risk_scan.py
+++ b/tools/risk_scan.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Scan git diffs for potentially risky changes.
+
+Flags:
+- dependency manifest changes
+- workflow changes
+- added lines that introduce network calls or shell/process execution
+
+Dependency-free by design for CI portability.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+DEPENDENCY_FILES = {
+    "requirements.txt",
+    "requirements-dev.txt",
+    "pyproject.toml",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "go.mod",
+    "go.sum",
+    "Cargo.toml",
+    "Cargo.lock",
+}
+
+WORKFLOW_PREFIXES = (
+    ".github/workflows/",
+)
+
+CONTENT_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("network-call", re.compile(r"\b(requests\.|httpx\.|urllib\.|fetch\(|axios\(|curl\s+https?://|wget\s+https?://)")),
+    ("process-exec", re.compile(r"\b(subprocess\.|os\.system\(|exec\(|spawn\(|child_process\.|Runtime\.getRuntime\(\)\.exec)")),
+    ("shell-script", re.compile(r"\b(sh\s+-c|bash\s+-c|powershell(\.exe)?\s+-[Cc]ommand)")),
+]
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    location: str
+    detail: str
+
+
+def _run_git(args: list[str]) -> str:
+    proc = subprocess.run(["git", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    return proc.stdout
+
+
+def scan_paths(diff_ref: str) -> list[Finding]:
+    out = _run_git(["diff", "--name-only", diff_ref])
+    findings: list[Finding] = []
+    for path in [p.strip() for p in out.splitlines() if p.strip()]:
+        filename = path.split("/")[-1]
+        if filename in DEPENDENCY_FILES:
+            findings.append(Finding("dependency-file", path, "Dependency manifest changed"))
+        if path.startswith(WORKFLOW_PREFIXES):
+            findings.append(Finding("workflow-change", path, "GitHub workflow changed"))
+    return findings
+
+
+def scan_content(diff_ref: str) -> list[Finding]:
+    out = _run_git(["diff", "-U0", diff_ref])
+    findings: list[Finding] = []
+    current_file = "unknown"
+
+    for raw_line in out.splitlines():
+        if raw_line.startswith("+++ b/"):
+            current_file = raw_line[6:]
+            continue
+        if not raw_line.startswith("+") or raw_line.startswith("+++"):
+            continue
+
+        line = raw_line[1:]
+        for kind, pattern in CONTENT_PATTERNS:
+            if pattern.search(line):
+                findings.append(Finding(kind, current_file, line.strip()))
+                break
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Scan diff for risky changes")
+    parser.add_argument("--diff-ref", default="HEAD~1..HEAD", help="Git diff ref/range to scan")
+    parser.add_argument(
+        "--fail-on-findings",
+        action="store_true",
+        help="Return exit code 1 when any findings exist",
+    )
+    args = parser.parse_args()
+
+    try:
+        findings = [*scan_paths(args.diff_ref), *scan_content(args.diff_ref)]
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if not findings:
+        print(f"PASS no risky changes detected in {args.diff_ref}")
+        return 0
+
+    print(f"RISK findings in {args.diff_ref}:")
+    for f in findings:
+        print(f"- [{f.kind}] {f.location}: {f.detail}")
+
+    return 1 if args.fail_on_findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/task_broker.py
+++ b/tools/task_broker.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""task_broker.py
+
+Generate an agent-ready implementation brief from a GitHub issue.
+
+Input options:
+1) --issue-json <path> (supports "-" for stdin)
+2) --repo owner/name --issue <number> (uses gh CLI: gh issue view --json ...)
+
+Output:
+- Markdown brief to stdout or --out file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class IssueData:
+    number: int
+    title: str
+    body: str
+    url: str
+    labels: list[str]
+
+
+HEADING_ALIASES: dict[str, list[str]] = {
+    "goal": ["goal", "objective", "outcome"],
+    "non_goals": ["non-goals", "non goals", "out of scope", "not in scope"],
+    "acceptance": ["acceptance criteria", "acceptance", "done when", "definition of done"],
+    "files": ["files likely touched", "files", "areas impacted", "paths"],
+    "safety": ["safety constraints", "safety", "security constraints", "constraints"],
+    "verify": ["how to verify", "verification", "test plan", "validation"],
+}
+
+
+SECTION_ORDER = ["goal", "non_goals", "acceptance", "files", "safety", "verify"]
+
+
+DEFAULTS = {
+    "goal": "- Deliver the requested issue outcome with minimal scope and clear verification.",
+    "non_goals": "- Avoid unrelated refactors, style-only edits, or broad architecture changes.",
+    "acceptance": "- [ ] The implementation meets issue requirements and is reviewable.",
+    "files": "- Identify exact files once implementation starts.",
+    "safety": "- Do not introduce secrets, unsafe shell execution, or unnecessary dependency risk.",
+    "verify": "- Run relevant checks and include command/output in PR summary.",
+}
+
+
+def _normalize_heading(text: str) -> str:
+    t = text.strip().lower().strip(":# ")
+    t = re.sub(r"\s+", " ", t)
+    for key, aliases in HEADING_ALIASES.items():
+        if t in aliases:
+            return key
+    return ""
+
+
+def _parse_sections(body: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {k: [] for k in SECTION_ORDER}
+    current = ""
+
+    for raw_line in body.splitlines():
+        line = raw_line.rstrip()
+        m = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", line)
+        if m:
+            key = _normalize_heading(m.group(1))
+            current = key if key else ""
+            continue
+
+        bullet = re.match(r"^\s*[-*]\s+(.+?)\s*$", line)
+        if bullet and not current:
+            maybe_key = _normalize_heading(bullet.group(1))
+            if maybe_key:
+                current = maybe_key
+                continue
+
+        if current:
+            sections[current].append(line)
+
+    out: dict[str, str] = {}
+    for key in SECTION_ORDER:
+        content = "\n".join(sections[key]).strip()
+        if content:
+            out[key] = content
+    return out
+
+
+def _extract_labels(raw: Any) -> list[str]:
+    labels: list[str] = []
+    if isinstance(raw, list):
+        for l in raw:
+            if isinstance(l, dict) and isinstance(l.get("name"), str):
+                labels.append(l["name"])
+            elif isinstance(l, str):
+                labels.append(l)
+    return labels
+
+
+def parse_issue_json(payload: dict[str, Any]) -> IssueData:
+    number = payload.get("number")
+    title = payload.get("title")
+    body = payload.get("body") or ""
+    url = payload.get("url") or payload.get("html_url") or ""
+    labels = _extract_labels(payload.get("labels", []))
+
+    if not isinstance(number, int):
+        raise ValueError("Issue JSON missing integer 'number'.")
+    if not isinstance(title, str) or not title.strip():
+        raise ValueError("Issue JSON missing non-empty 'title'.")
+    if not isinstance(body, str):
+        raise ValueError("Issue JSON field 'body' must be a string.")
+    if not isinstance(url, str):
+        raise ValueError("Issue JSON field 'url' must be a string.")
+
+    return IssueData(number=number, title=title.strip(), body=body, url=url.strip(), labels=labels)
+
+
+def load_issue_from_file(path: str) -> IssueData:
+    if path == "-":
+        payload = json.load(sys.stdin)
+    else:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    return parse_issue_json(payload)
+
+
+def load_issue_from_gh(repo: str, issue_number: int) -> IssueData:
+    if not shutil.which("gh"):
+        raise RuntimeError("gh CLI not found on PATH.")
+
+    cmd = [
+        "gh",
+        "issue",
+        "view",
+        str(issue_number),
+        "--repo",
+        repo,
+        "--json",
+        "number,title,body,url,labels",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if res.returncode != 0:
+        msg = res.stderr.strip() or res.stdout.strip() or f"gh failed with code {res.returncode}"
+        raise RuntimeError(msg)
+
+    payload = json.loads(res.stdout)
+    return parse_issue_json(payload)
+
+
+def render_markdown(issue: IssueData) -> str:
+    sections = _parse_sections(issue.body)
+
+    def section(key: str) -> str:
+        return sections.get(key, DEFAULTS[key]).strip()
+
+    labels = ", ".join(issue.labels) if issue.labels else "(none)"
+
+    return f"""# Agent Brief: #{issue.number} {issue.title}
+
+Source issue: {issue.url or '(missing URL)'}
+Labels: {labels}
+
+## Goal
+{section('goal')}
+
+## Non-goals
+{section('non_goals')}
+
+## Acceptance criteria (testable)
+{section('acceptance')}
+
+## Files likely touched
+{section('files')}
+
+## Safety constraints
+{section('safety')}
+
+## How to verify
+{section('verify')}
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a task brief from a GitHub issue")
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--issue-json", help="Path to issue JSON file, or '-' for stdin")
+    src.add_argument("--issue", type=int, help="Issue number (requires --repo)")
+    parser.add_argument("--repo", help="owner/repo (required with --issue)")
+    parser.add_argument("--out", help="Write output markdown to a file")
+
+    args = parser.parse_args()
+
+    try:
+        if args.issue_json:
+            issue = load_issue_from_file(args.issue_json)
+        else:
+            if not args.repo:
+                parser.error("--repo is required when using --issue")
+            issue = load_issue_from_gh(args.repo, args.issue)
+
+        output = render_markdown(issue)
+        if args.out:
+            out_path = Path(args.out)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(output, encoding="utf-8")
+        else:
+            sys.stdout.write(output)
+
+        return 0
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_risk_scan.py
+++ b/tools/test_risk_scan.py
@@ -1,0 +1,32 @@
+import re
+import unittest
+
+from tools.risk_scan import CONTENT_PATTERNS
+
+
+class RiskScanPatternTests(unittest.TestCase):
+    def _matches_kind(self, line: str):
+        for kind, pattern in CONTENT_PATTERNS:
+            if pattern.search(line):
+                return kind
+        return None
+
+    def test_detects_network_calls(self):
+        self.assertEqual(self._matches_kind("requests.get('https://example.com')"), "network-call")
+        self.assertEqual(self._matches_kind("curl https://example.com"), "network-call")
+
+    def test_detects_process_execution(self):
+        self.assertEqual(self._matches_kind("subprocess.run(['ls'])"), "process-exec")
+        self.assertEqual(self._matches_kind("os.system('rm -rf /')"), "process-exec")
+
+    def test_detects_shell_injections(self):
+        self.assertEqual(self._matches_kind("bash -c 'echo hi'"), "shell-script")
+        self.assertEqual(self._matches_kind("powershell.exe -Command Get-ChildItem"), "shell-script")
+
+    def test_ignores_benign_lines(self):
+        self.assertIsNone(self._matches_kind("print('hello world')"))
+        self.assertIsNone(self._matches_kind("def parse_config(path):"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_task_broker.py
+++ b/tools/test_task_broker.py
@@ -1,9 +1,14 @@
 import unittest
 
-from tools.task_broker import parse_issue_json, render_markdown
+from tools.task_broker import parse_issue_json, parse_issue_url, render_markdown
 
 
 class TaskBrokerTests(unittest.TestCase):
+    def test_parse_issue_url(self):
+        repo, issue_number = parse_issue_url("https://github.com/RedLynx101/swarmkit/issues/8")
+        self.assertEqual(repo, "RedLynx101/swarmkit")
+        self.assertEqual(issue_number, 8)
+
     def test_parse_issue_json_accepts_label_dicts(self):
         issue = parse_issue_json(
             {

--- a/tools/test_task_broker.py
+++ b/tools/test_task_broker.py
@@ -1,0 +1,62 @@
+import unittest
+
+from tools.task_broker import parse_issue_json, render_markdown
+
+
+class TaskBrokerTests(unittest.TestCase):
+    def test_parse_issue_json_accepts_label_dicts(self):
+        issue = parse_issue_json(
+            {
+                "number": 42,
+                "title": "Add broker",
+                "body": "",
+                "url": "https://example.com/42",
+                "labels": [{"name": "P1"}, {"name": "agent-task"}],
+            }
+        )
+        self.assertEqual(issue.labels, ["P1", "agent-task"])
+
+    def test_render_markdown_maps_sections_when_present(self):
+        issue = parse_issue_json(
+            {
+                "number": 8,
+                "title": "Build task broker",
+                "body": """
+## Goal
+- Turn issue into brief
+
+## Acceptance Criteria
+- [ ] Produces markdown
+
+## How to verify
+- Run on issue #8
+""",
+                "url": "https://example.com/8",
+                "labels": ["P2"],
+            }
+        )
+
+        output = render_markdown(issue)
+        self.assertIn("# Agent Brief: #8 Build task broker", output)
+        self.assertIn("- Turn issue into brief", output)
+        self.assertIn("- [ ] Produces markdown", output)
+        self.assertIn("- Run on issue #8", output)
+
+    def test_render_markdown_uses_defaults_when_sections_missing(self):
+        issue = parse_issue_json(
+            {
+                "number": 1,
+                "title": "Minimal",
+                "body": "No structured sections",
+                "url": "https://example.com/1",
+                "labels": [],
+            }
+        )
+
+        output = render_markdown(issue)
+        self.assertIn("Deliver the requested issue outcome", output)
+        self.assertIn("Avoid unrelated refactors", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `tools/task_broker.py` to generate agent-ready markdown briefs from GitHub issues
- support `--issue-json` input and direct `gh issue view` fetch mode
- map issue body headings into brief sections with defaults when missing
- add unit tests for section mapping/default behavior
- run tooling tests in CI for `tools/test_*.py`
- document usage in `tools/README.md` and `docs/ISSUE_BRIEFS.md`

## Verification
- `python3 tools/task_broker.py --help`
- `python3 tools/task_broker.py --repo RedLynx101/swarmkit --issue 8 --out /tmp/swarmkit-issue-8-brief.md`
- `python3 -m unittest discover -s tools -p 'test_*.py'`
- `python3 -m py_compile tools/task_broker.py tools/test_task_broker.py`

Closes #8
