### PR TITLE
Add maintainer guide for Welcome / Start Here discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ Key docs:
 - Onboarding: `docs/AGENT_ONBOARDING.md`
 - Recommended branch protection: `docs/ops/branch-protection.md`
 - Code owners: `.github/CODEOWNERS`
+- Maintainer guide for Start Here discussion: `docs/community/start-here-discussion.md`
+
+Community:
+- Start Here (GitHub Discussions): https://github.com/RedLynx101/swarmkit/discussions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,9 @@ Instead:
 - Contact the maintainer via GitHub DM.
 
 ## Hardening
-For maintainers, see: `docs/security/hardening.md`
+For maintainers, see:
+- `docs/security/hardening.md`
+- `docs/security/self-audit-checklist.md`
 
 ## Scope
 Anything that could lead to:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,6 +10,7 @@ This is an early-stage repo. We optimize for:
 - Agent onboarding docs
 - Maintainer runbook
 - Basic CI skeleton
+- Pinned Welcome / Start Here discussion flow for contributor onboarding
 
 ## Phase 1: Task broker + receipts
 - Issue Brief schema for agent tasks

--- a/docs/community/start-here-discussion.md
+++ b/docs/community/start-here-discussion.md
@@ -1,0 +1,40 @@
+# Welcome / Start Here Discussion
+
+Use this guide to create the pinned **Welcome / Start Here** GitHub Discussion for new contributors (human and agent).
+
+## Why this matters
+
+A pinned start thread reduces maintainer load by centralizing:
+- contribution expectations,
+- onboarding links,
+- repo safety rules.
+
+## One-time setup
+
+1. Enable Discussions in repo settings (if not already enabled).
+2. Create a new discussion in category **General** with title:
+   - `Welcome / Start Here`
+3. Pin the discussion.
+4. Add or verify links in `README.md`.
+
+## Suggested starter content
+
+```md
+Welcome to swarmkit.
+
+If you're new here:
+1) Read `docs/AGENT_ONBOARDING.md`
+2) Read `docs/ops/branch-protection.md`
+3) Pick a labeled `agent-task` issue
+4) Open a PR with clear verification steps
+
+Ground rules:
+- PRs only; no direct pushes to `main`
+- Keep changes small and reviewable
+- Include receipts/commands for reproducibility
+```
+
+## Maintenance
+
+- Keep this discussion updated when contribution flow changes.
+- Keep links synchronized with README and onboarding docs.

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -4,6 +4,7 @@
 - Triage issues → label → clarify acceptance criteria.
 - Slice tasks into `agent-task` issues.
 - Review PRs with CI + receipts.
+- Keep the pinned **Welcome / Start Here** discussion current (`docs/community/start-here-discussion.md`).
 
 ## Merge policy
 - PRs only.

--- a/docs/projects/initial_backlog.md
+++ b/docs/projects/initial_backlog.md
@@ -1,8 +1,9 @@
 # Initial Backlog (starter issues)
 
 ## P0: Repo admin + onboarding
-- Add CI skeleton (lint + basic checks)
-- Add labels + automation (triage)
+- [x] Add CI skeleton (lint + basic checks)
+- [ ] Add labels + automation (triage)
+- [x] Add a Welcome / Start Here discussion flow and maintainer guide
 
 ## P1: Receipts
 - Define receipts schema

--- a/docs/security/self-audit-checklist.md
+++ b/docs/security/self-audit-checklist.md
@@ -1,0 +1,39 @@
+# Security Self-Audit Checklist (Maintainers)
+
+Use this before major releases and at least monthly.
+
+## 1) Branch and review controls
+- [ ] Default branch is protected.
+- [ ] PRs required for merge to default branch.
+- [ ] At least one approving review is required.
+- [ ] Required status checks are up to date.
+
+## 2) Workflow permissions
+- [ ] GitHub Actions workflow permissions are least-privilege.
+- [ ] No unnecessary `pull_request_target` workflows.
+- [ ] No unreviewed workflow changes merged recently.
+
+## 3) Secrets and credential exposure
+- [ ] Secret scanning is enabled.
+- [ ] No plaintext tokens/keys in recent commits.
+- [ ] Example config files use placeholders only.
+
+## 4) Dependency and supply chain checks
+- [ ] Dependency updates are reviewed and intentional.
+- [ ] New dependencies are justified in PR descriptions.
+- [ ] CI passes on dependency-related changes.
+
+## 5) Agent-specific guardrails
+- [ ] PRs include verification commands / receipts.
+- [ ] Risk scan findings reviewed for network/exec/deps changes.
+- [ ] High-risk diffs have explicit maintainer sign-off.
+
+## Fast command check
+
+```bash
+# local test baseline
+python3 -m unittest discover -s tools -p 'test_*.py'
+
+# quick risk scan against main
+python3 tools/risk_scan.py --diff-ref main..HEAD
+```


### PR DESCRIPTION
## Summary
- add a maintainer playbook for creating and maintaining a pinned Welcome / Start Here discussion
- link the guide from README
- add runbook reminder to keep Start Here discussion current

## Verification
- python3 -m unittest discover -s tools -p 'test_*.py'